### PR TITLE
Avoiding infinite recursion for long expressions.

### DIFF
--- a/src/main/java/com/bpodgursky/jbool_expressions/And.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/And.java
@@ -1,13 +1,17 @@
 package com.bpodgursky.jbool_expressions;
 
+import java.util.List;
+
 import org.apache.commons.lang.StringUtils;
 
-import java.util.List;
+import com.google.common.base.Optional;
 
 public class And<K> extends NExpression<K> {
   public static final String  EXPR_TYPE = "and";
+  private Optional<String> cachedStringRepresentation = Optional.absent();
 
-  private And(List<Expression<K>> children) {
+
+    private And(List<Expression<K>> children) {
     super(children);
   }
 
@@ -16,8 +20,10 @@ public class And<K> extends NExpression<K> {
     return new And<K>(children);
   }
 
-  public String toString(){
-    return "("+ StringUtils.join(expressions, " & ")+")";
+  public String toString() {
+      if (!cachedStringRepresentation.isPresent())
+          cachedStringRepresentation = Optional.of("("+ StringUtils.join(expressions, " & ")+")");
+      return cachedStringRepresentation.get();
   }
 
   public static <K> And<K> of(Expression<K> child1, Expression<K> child2, Expression<K> child3){

--- a/src/main/java/com/bpodgursky/jbool_expressions/Not.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/Not.java
@@ -1,12 +1,14 @@
 package com.bpodgursky.jbool_expressions;
 
+import java.util.List;
+
 import com.bpodgursky.jbool_expressions.rules.Rule;
 import com.bpodgursky.jbool_expressions.rules.RuleSet;
-
-import java.util.List;
+import com.google.common.base.Optional;
 
 public class Not<K> extends Expression<K> {
   public static final String EXPR_TYPE = "not";
+  private Optional<String> cachedStringRepresentation = Optional.absent();
 
   private final Expression<K> e;
 
@@ -19,7 +21,9 @@ public class Not<K> extends Expression<K> {
   }
 
   public String toString(){
-    return "!"+e;
+      if (!cachedStringRepresentation.isPresent())
+          cachedStringRepresentation = Optional.of("!" + e);
+    return cachedStringRepresentation.get();
   }
 
   @Override

--- a/src/main/java/com/bpodgursky/jbool_expressions/Or.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/Or.java
@@ -1,11 +1,14 @@
 package com.bpodgursky.jbool_expressions;
 
+import java.util.List;
+
 import org.apache.commons.lang.StringUtils;
 
-import java.util.List;
+import com.google.common.base.Optional;
 
 public class Or<K> extends NExpression<K> {
   public static final String EXPR_TYPE = "or";
+  private Optional<String> cachedStringRepresentation = Optional.absent();
 
   private Or(List<Expression<K>> children) {
     super(children);
@@ -16,8 +19,10 @@ public class Or<K> extends NExpression<K> {
     return new Or<K>(children);
   }
 
-  public String toString(){
-    return "("+ StringUtils.join(expressions, " | ")+")";
+  public String toString() {
+      if (!cachedStringRepresentation.isPresent())
+          cachedStringRepresentation = Optional.of("(" + StringUtils.join(expressions, " | ") + ")");
+      return cachedStringRepresentation.get();
   }
 
   @Override
@@ -39,6 +44,8 @@ public class Or<K> extends NExpression<K> {
 
     return true;
   }
+
+
 
   public static <K> Or<K> of(Expression<K> child1, Expression<K> child2, Expression<K> child3, Expression<K> child4){
     return of(ExprUtil.<K>list(child1, child2, child3, child4));

--- a/src/main/java/com/bpodgursky/jbool_expressions/parsers/ExprParser.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/parsers/ExprParser.java
@@ -1,9 +1,7 @@
 package com.bpodgursky.jbool_expressions.parsers;
 
-import com.bpodgursky.jbool_expressions.*;
-import com.bpodgursky.jbool_expressions.parsers.BooleanExprLexer;
-import com.bpodgursky.jbool_expressions.parsers.BooleanExprParser;
-import com.google.common.collect.Lists;
+import java.util.List;
+
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CommonTokenStream;
 import org.antlr.runtime.RecognitionException;
@@ -11,11 +9,18 @@ import org.antlr.runtime.TokenStream;
 import org.antlr.runtime.tree.CommonTree;
 import org.antlr.runtime.tree.Tree;
 
-import java.util.List;
+import com.bpodgursky.jbool_expressions.And;
+import com.bpodgursky.jbool_expressions.Expression;
+import com.bpodgursky.jbool_expressions.Literal;
+import com.bpodgursky.jbool_expressions.Not;
+import com.bpodgursky.jbool_expressions.Or;
+import com.bpodgursky.jbool_expressions.Variable;
+import com.google.common.collect.Lists;
 
 public class ExprParser {
 
   public static Expression<String> parse(String expression){
+      System.out.println(expression);
     return parse(expression, new IdentityMap());
   }
 

--- a/src/test/java/com/bpodgursky/jbool_expressions/TestExpressions.java
+++ b/src/test/java/com/bpodgursky/jbool_expressions/TestExpressions.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.bpodgursky.jbool_expressions.eval.EvalEngine;
+import com.bpodgursky.jbool_expressions.parsers.ExprParser;
 import com.bpodgursky.jbool_expressions.rules.RuleSet;
 import com.google.common.collect.Maps;
 
@@ -93,4 +94,17 @@ public class TestExpressions extends JBoolTestCase {
     assertSimplify("aBC_D9", "aBC_D9 & (aBC_D9 | BCD)");
     assertSimplify("'not even valid'", "'not even valid' & ('not even valid' | BCD)");
   }
+
+  public void testLongExpression() {
+      String exp = "(122036 | 122037 | 122039 | 122040 | 122042 | 122043 | 122045 | 122046 | 122048 | 122049 | " +
+              "122051 | 122052 | 122054 | 122055 | 122057 | 122058 | 122060 | 122061 | 122063 | 122064 | 122066 | " +
+              "122067 | 122069 | 122070 | 169225 | 169226 | 169228 | 169229 | 169231 | 169232 | 169234 | 169235 | " +
+              "169237 | 169238 | 169240 | 169241 | 169243 | 169244 | 169246 | 169247 | 169249 | 169250 | 169252 | " +
+              "169253 | 169255 | 169256 | 169258 | 169259 | 169261 | 169262 | 169264 | 169265 | 106925 | 106926 | " +
+              "165611)";
+      ExprParser.parse(exp);
+      ExprParser.parse(exp.replaceAll("\\|","&"));
+      ExprParser.parse(exp.replaceAll("\\|","& !"));
+  }
+
 }


### PR DESCRIPTION
Fixing: https://github.com/bpodgursky/jbool_expressions/issues/6

Thread dump pre-issue:

```
"http-nio-8080-exec-1" daemon prio=5 tid=0x00007ff41f0c9800 nid=0x5e0f runnable [0x0000000127a5b000]
   java.lang.Thread.State: RUNNABLE
	at java.lang.String.valueOf(String.java:2854)
	at java.lang.StringBuffer.append(StringBuffer.java:232)
	- locked <0x0000000747ba98b0> (a java.lang.StringBuffer)
	at org.apache.commons.lang.StringUtils.join(StringUtils.java:3239)
	at org.apache.commons.lang.StringUtils.join(StringUtils.java:3184)
	at com.bpodgursky.jbool_expressions.Or.toString(Or.java:20)
	at java.lang.String.valueOf(String.java:2854)
	at java.lang.StringBuffer.append(StringBuffer.java:232)
	- locked <0x0000000747ba9808> (a java.lang.StringBuffer)
	at org.apache.commons.lang.StringUtils.join(StringUtils.java:3239)
	at org.apache.commons.lang.StringUtils.join(StringUtils.java:3184)
	at com.bpodgursky.jbool_expressions.Or.toString(Or.java:20)
	at java.lang.String.valueOf(String.java:2854)
	at java.lang.StringBuffer.append(StringBuffer.java:232)
	- locked <0x0000000747ba95a8> (a java.lang.StringBuffer)
```

