### PR TITLE
Use standard java equals and hash code for performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -165,6 +165,15 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/bpodgursky/jbool_expressions/And.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/And.java
@@ -12,7 +12,7 @@ public class And<K> extends NExpression<K> {
 
 
   private And(List<? extends Expression<K>> children) {
-    super(children, 2312);
+    super(children, 1483);
   }
 
   @Override

--- a/src/main/java/com/bpodgursky/jbool_expressions/And.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/And.java
@@ -12,7 +12,7 @@ public class And<K> extends NExpression<K> {
 
 
   private And(List<? extends Expression<K>> children) {
-    super(children);
+    super(children, 2312);
   }
 
   @Override
@@ -41,25 +41,6 @@ public class And<K> extends NExpression<K> {
 
   public static <K> And<K> of(List<? extends Expression<K>> children) {
     return new And<K>(children);
-  }
-
-  @Override
-  public boolean equals(Expression expr) {
-    if (!(expr instanceof And)) {
-      return false;
-    }
-    And other = (And)expr;
-
-    if (other.expressions.length != expressions.length) {
-      return false;
-    }
-
-    for (int i = 0; i < expressions.length; i++) {
-      if (!expressions[i].equals(other.expressions[i])) {
-        return false;
-      }
-    }
-    return true;
   }
 
   @Override

--- a/src/main/java/com/bpodgursky/jbool_expressions/ExprUtil.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/ExprUtil.java
@@ -3,7 +3,7 @@ package com.bpodgursky.jbool_expressions;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -66,7 +66,7 @@ public class ExprUtil {
   }
 
   public static <K> Expression<K>[] allExceptMatch(Collection<Expression<K>> exprs, Set<? extends Expression<K>> omit){
-    Set<Expression<K>> andTerms = new HashSet<Expression<K>>();
+    Set<Expression<K>> andTerms = new LinkedHashSet<Expression<K>>();
     for(Expression<K> eachExpr: exprs){
       if(!omit.contains(eachExpr)){
         andTerms.add(eachExpr);
@@ -78,11 +78,11 @@ public class ExprUtil {
 
   public static <K> Expression<K>[] allExceptMatch(List<Expression<K>> exprs, Expression<K> omit) {
     //noinspection unchecked
-    return allExceptMatch(exprs.toArray(new Expression[0]), omit);
+    return allExceptMatch(exprs.toArray(new Expression[exprs.size()]), omit);
   }
 
     public static <K> Expression<K>[] allExceptMatch(Expression<K>[] exprs, Expression<K> omit){
-    Set<Expression<K>> andTerms = new HashSet<Expression<K>>();
+    Set<Expression<K>> andTerms = new LinkedHashSet<Expression<K>>();
     for(Expression<K> eachExpr: exprs){
       if(!eachExpr.equals(omit)){
         andTerms.add(eachExpr);
@@ -121,7 +121,7 @@ public class ExprUtil {
     }else if(expr instanceof Not){
       return getVariables(((Not<K>) expr).getE());
     }else if(expr instanceof NExpression){
-      Set<K> vars = new HashSet<K>();
+      Set<K> vars = new LinkedHashSet<K>();
       for(Expression<K> child: ((NExpression<K>)expr).expressions){
         vars.addAll(getVariables(child));
       }

--- a/src/main/java/com/bpodgursky/jbool_expressions/Expression.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/Expression.java
@@ -7,22 +7,16 @@ import com.bpodgursky.jbool_expressions.rules.Rule;
 public abstract class Expression<K> implements Comparable<Expression> {
 
   public int compareTo(Expression o) {
-    return toString().compareTo(o.toString());
-  }
-
-  @Override
-  public boolean equals(Object o){
-    return o instanceof Expression && equals((Expression) o);
-  }
-
-  @Override
-  public int hashCode(){
-    return toString().hashCode();
+    int compare = Integer.compare(hashCode(), o.hashCode());
+    if(compare == 0 && !equals(o)) {
+      // If hashcode matches and expressions are not equal then we may have a hash collision.
+      // This is very unlikely to happen but if it does then go for string comparison (slow).
+      return toString().compareTo(o.toString());
+    }
+    return compare;
   }
 
   public abstract Expression<K> apply(List<Rule<?, K>> rules);
-
-  public abstract boolean equals(Expression expr);
 
   public abstract String getExprType();
 }

--- a/src/main/java/com/bpodgursky/jbool_expressions/Literal.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/Literal.java
@@ -46,14 +46,18 @@ public class Literal<K> extends Expression<K>{
   public Expression<K> apply(List<Rule<?, K>> rules) {
     return this;
   }
-
-  @Override
-  public boolean equals(Expression expr) {
-    return expr instanceof Literal && ((Literal)expr).getValue() == getValue();
-  }
-
   @Override
   public String getExprType() {
     return EXPR_TYPE;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return this == o;
+  }
+
+  @Override
+  public int hashCode() {
+    return Boolean.hashCode(value);
   }
 }

--- a/src/main/java/com/bpodgursky/jbool_expressions/NExpression.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/NExpression.java
@@ -2,6 +2,7 @@ package com.bpodgursky.jbool_expressions;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import com.bpodgursky.jbool_expressions.rules.Rule;
 import com.bpodgursky.jbool_expressions.rules.RuleSet;
@@ -10,14 +11,23 @@ import com.google.common.collect.Lists;
 public abstract class NExpression<K> extends Expression<K>{
 
   public final Expression<K>[] expressions;
+  private int hashCode;
 
-  protected NExpression(List<? extends Expression<K>> expressions){
+  /**
+   * @param expressions The expressions
+   * @param seed Each subclass of NExpression should have a different seed for hash code.
+   *             It allows better hash code generation.
+   */
+  protected NExpression(List<? extends Expression<K>> expressions, int seed){
     if(expressions.isEmpty()){
       throw new IllegalArgumentException("Arguments length 0!");
     }
 
-    this.expressions = expressions.toArray(ExprUtil.<K>expr(0));
+    this.expressions = expressions.toArray(ExprUtil.<K>expr(expressions.size()));
     Arrays.sort(this.expressions);
+
+    //For NExpressions we compute the hash code up front and cache it.
+    hashCode = Objects.hash(seed, Arrays.hashCode(this.expressions));
   }
 
   @Override
@@ -34,4 +44,18 @@ public abstract class NExpression<K> extends Expression<K>{
   }
 
   public abstract NExpression<K> create(List<? extends Expression<K>> children);
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    NExpression<?> that = (NExpression<?>) o;
+    return hashCode == that.hashCode &&
+            Arrays.equals(expressions, that.expressions);
+  }
+
+  @Override
+  public int hashCode() {
+    return hashCode;
+  }
 }

--- a/src/main/java/com/bpodgursky/jbool_expressions/Not.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/Not.java
@@ -1,6 +1,7 @@
 package com.bpodgursky.jbool_expressions;
 
 import java.util.List;
+import java.util.Objects;
 
 import com.bpodgursky.jbool_expressions.rules.Rule;
 import com.bpodgursky.jbool_expressions.rules.RuleSet;
@@ -32,11 +33,6 @@ public class Not<K> extends Expression<K> {
     return new Not<K>(RuleSet.applyAll(e, rules));
   }
 
-  @Override
-  public boolean equals(Expression expr) {
-    return expr instanceof Not && ((Not)expr).getE().equals(getE());
-  }
-
   public static <K> Not<K> of(Expression<K> e) {
     return new Not<K>(e);
   }
@@ -44,5 +40,19 @@ public class Not<K> extends Expression<K> {
   @Override
   public String getExprType() {
     return EXPR_TYPE;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Not<?> not = (Not<?>) o;
+    return Objects.equals(e, not.e);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(e);
   }
 }

--- a/src/main/java/com/bpodgursky/jbool_expressions/Or.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/Or.java
@@ -11,7 +11,7 @@ public class Or<K> extends NExpression<K> {
   private Optional<String> cachedStringRepresentation = Optional.absent();
 
   private Or(List<? extends Expression<K>> children) {
-    super(children);
+    super(children, 2313);
   }
 
   @Override
@@ -25,27 +25,6 @@ public class Or<K> extends NExpression<K> {
     }
     return cachedStringRepresentation.get();
   }
-
-  @Override
-  public boolean equals(Expression expr) {
-    if (!(expr instanceof Or)) {
-      return false;
-    }
-    Or other = (Or)expr;
-
-    if (other.expressions.length != expressions.length) {
-      return false;
-    }
-
-    for (int i = 0; i < expressions.length; i++) {
-      if (!expressions[i].equals(other.expressions[i])) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
 
   public static <K> Or<K> of(Expression<K> child1, Expression<K> child2, Expression<K> child3, Expression<K> child4) {
     return of(ExprUtil.<K>list(child1, child2, child3, child4));

--- a/src/main/java/com/bpodgursky/jbool_expressions/Or.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/Or.java
@@ -11,7 +11,7 @@ public class Or<K> extends NExpression<K> {
   private Optional<String> cachedStringRepresentation = Optional.absent();
 
   private Or(List<? extends Expression<K>> children) {
-    super(children, 2313);
+    super(children, 1487);
   }
 
   @Override

--- a/src/main/java/com/bpodgursky/jbool_expressions/Variable.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/Variable.java
@@ -3,6 +3,7 @@ package com.bpodgursky.jbool_expressions;
 import com.bpodgursky.jbool_expressions.rules.Rule;
 
 import java.util.List;
+import java.util.Objects;
 
 public class Variable<K> extends Expression<K> {
   public static final String EXPR_TYPE = "variable";
@@ -26,11 +27,6 @@ public class Variable<K> extends Expression<K> {
     return this;
   }
 
-  @Override
-  public boolean equals(Expression expr) {
-    return expr instanceof Variable && ((Variable)expr).getValue().equals(getValue());
-  }
-
   public static <K> Variable<K> of(K value){
     return new Variable<K>(value);
   }
@@ -38,5 +34,18 @@ public class Variable<K> extends Expression<K> {
   @Override
   public String getExprType() {
     return EXPR_TYPE;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Variable<?> variable = (Variable<?>) o;
+    return Objects.equals(value, variable.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
   }
 }

--- a/src/test/java/com/bpodgursky/jbool_expressions/TestAnd.java
+++ b/src/test/java/com/bpodgursky/jbool_expressions/TestAnd.java
@@ -2,6 +2,8 @@ package com.bpodgursky.jbool_expressions;
 
 import com.bpodgursky.jbool_expressions.parsers.ExprParser;
 
+import static org.junit.Assert.assertNotEquals;
+
 public class TestAnd extends JBoolTestCase {
 
   public void testSimplify() {
@@ -26,24 +28,33 @@ public class TestAnd extends JBoolTestCase {
   }
 
   public void testToPos() {
-    assertToPos("((A | C) & B & D)", "(A & B & D) | (B & C & D)");
-    assertToPos("(!C | !D | A)", "((A & !B) | (A & D) | (!C & D) | !D)");
+    assertToPos("(B & D & (A | C))", "(A & B & D) | (B & C & D)");
+    assertToPos("(A | !C | !D)", "((A & !B) | (A & D) | (!C & D) | !D)");
     assertEvaluateSame(
         ExprParser.parse("((A & !B) | (A & D) | (!C & D) | !D)"),
         ExprParser.parse("(!C | !D | A)")
     );
 
-    assertToPos("((A | C) & B & D)", "(A & B & D) | (B & C & D)");
+    assertToPos("(B & D & (A | C))", "(A & B & D) | (B & C & D)");
   }
 
 
   public void testToSopPerformance() throws Exception {
-    assertToPos("((A | B) & (C | D | E | F) & (K | L | M) & N)", "((A | B) & (C | D | E | F) & (K | L | M) & N)");
+    assertToPos("(N & (A | B) & (K | L | M) & (C | D | E | F))", "((A | B) & (C | D | E | F) & (K | L | M) & N)");
   }
 
   public void testSimplifyChildren() {
     assertSimplify("(A | B)", "(A | B) & (A | B | C)");
     assertSimplify("(A & B)", "((A & B) | (A & B & C))");
+  }
+
+  public void testEqualsHashCode() {
+    assertEquals(And.of(Variable.of("A"), Variable.of("B")), And.of(Variable.of("B"), Variable.of("A")));
+    assertEquals(And.of(Variable.of("A"), Variable.of("B")).hashCode(), And.of(Variable.of("B"), Variable.of("A")).hashCode());
+    assertEquals(And.of(Variable.of("A"), Variable.of("B")).hashCode(), And.of(Variable.of("A"), Variable.of("B")).hashCode());
+    assertNotEquals(And.of(Variable.of("A"), Variable.of("B")), And.of(Variable.of("B"), Variable.of("C")));
+    assertNotEquals(And.of(Variable.of("A"), Variable.of("B")).hashCode(), And.of(Variable.of("A"), Variable.of("C")).hashCode());
+    assertNotEquals(And.of(Variable.of("A"), Variable.of("B")).hashCode(), Or.of(Variable.of("A"), Variable.of("B")).hashCode());
   }
 
 }

--- a/src/test/java/com/bpodgursky/jbool_expressions/TestAssign.java
+++ b/src/test/java/com/bpodgursky/jbool_expressions/TestAssign.java
@@ -16,7 +16,7 @@ public class TestAssign extends TestCase {
     );
 
     Expression<String> expr = RuleSet.assign(expr3, Collections.singletonMap("A", false));
-    assertEquals("((C | D) & B)", expr.toString());
+    assertEquals("(B & (C | D))", expr.toString());
 
     expr = RuleSet.assign(expr, Collections.singletonMap("B", true));
     assertEquals("(C | D)", expr.toString());

--- a/src/test/java/com/bpodgursky/jbool_expressions/TestExpressions.java
+++ b/src/test/java/com/bpodgursky/jbool_expressions/TestExpressions.java
@@ -20,7 +20,7 @@ public class TestExpressions extends JBoolTestCase {
         Variable.of("F")
     );
 
-    assertEquals("(!(A | true) & (C | D | false) & F)", expr.toString());
+    assertEquals("(F & !(A | true) & (C | D | false))", expr.toString());
 
     Set<String> allVars = new HashSet<String>(Arrays.asList("A", "C", "D", "F"));
     assertEquals(allVars, ExprUtil.getVariables(expr));

--- a/src/test/java/com/bpodgursky/jbool_expressions/TestNot.java
+++ b/src/test/java/com/bpodgursky/jbool_expressions/TestNot.java
@@ -7,6 +7,8 @@ import com.bpodgursky.jbool_expressions.rules.RuleSet;
 
 import java.util.Arrays;
 
+import static org.junit.Assert.assertNotEquals;
+
 public class TestNot extends JBoolTestCase {
 
   public void testSimplify(){
@@ -41,6 +43,11 @@ public class TestNot extends JBoolTestCase {
 
     assertSimplify("!B", "(! B)");
 
+  }
+
+  public void testEqualsHashCode() {
+    assertNotEquals(Variable.of("E"), Not.of(Variable.of("E")));
+    assertNotEquals(Variable.of("E").hashCode(), Not.of(Variable.of("E")).hashCode());
   }
 
 }

--- a/src/test/java/com/bpodgursky/jbool_expressions/TestOr.java
+++ b/src/test/java/com/bpodgursky/jbool_expressions/TestOr.java
@@ -1,5 +1,8 @@
 package com.bpodgursky.jbool_expressions;
 
+
+import static org.junit.Assert.assertNotEquals;
+
 public class TestOr extends JBoolTestCase {
 
   public void testSimplify(){
@@ -23,4 +26,15 @@ public class TestOr extends JBoolTestCase {
   public void testNExpr(){
     assertSimplify("true", "( A | B | A | ( true & (! (! true))))");
   }
+
+
+  public void testEqualsHashCode() {
+    assertEquals(Or.of(Variable.of("A"), Variable.of("B")), Or.of(Variable.of("B"), Variable.of("A")));
+    assertEquals(Or.of(Variable.of("A"), Variable.of("B")).hashCode(), Or.of(Variable.of("B"), Variable.of("A")).hashCode());
+    assertEquals(Or.of(Variable.of("A"), Variable.of("B")).hashCode(), Or.of(Variable.of("A"), Variable.of("B")).hashCode());
+    assertNotEquals(Or.of(Variable.of("A"), Variable.of("B")), Or.of(Variable.of("B"), Variable.of("C")));
+    assertNotEquals(Or.of(Variable.of("A"), Variable.of("B")).hashCode(), Or.of(Variable.of("A"), Variable.of("C")).hashCode());
+    assertNotEquals(Or.of(Variable.of("A"), Variable.of("B")).hashCode(), And.of(Variable.of("A"), Variable.of("B")).hashCode());
+  }
+
 }

--- a/src/test/java/com/bpodgursky/jbool_expressions/TestSimplify.java
+++ b/src/test/java/com/bpodgursky/jbool_expressions/TestSimplify.java
@@ -27,27 +27,27 @@ public class TestSimplify extends JBoolTestCase {
     assertSimplify("!A", "(!A) & ((!A) | B | D)");
 
     //  make sure it doesn't catch the opposite and/or case for whatever reason
-    assertSimplify("(((A | C) & B & D) | (A & C))", "((A | C) & B & D) | (A & C)");
+    assertSimplify("((A & C) | (B & D & (A | C)))", "((A | C) & B & D) | (A & C)");
 
 
     // test in isolation to catch a few potential errors
     ArrayList<Rule<?, String>> rules = Lists.<Rule<?, String>>newArrayList(new SimplifyNExprChildren<String>());
 
-    assertApply("((A & B) & A)", "(A & B) & A", rules);
+    assertApply("(A & (A & B))", "(A & B) & A", rules);
     assertApply("(A)", "A & (A | B)", rules);
     assertApply("(A)", "A | (A & B)", rules);
-    assertApply("((A | B) | A)", "(A | B) | A", rules);
+    assertApply("(A | (A | B))", "(A | B) | A", rules);
 
     // test CollapseNegation rules
     assertSimplify("(A | C | D)", "A | (!A & C) | D");
-    assertSimplify("((A & E) | C | D)", "(A & E) | (!(A & E) & C) | D");
+    assertSimplify("(C | D | (A & E))", "(A & E) | (!(A & E) & C) | D");
 
   }
 
   public void testPOS() {
-    assertToPos("((!C | !D | !E | !F) & A)", "A & (!A | !C | !D | !E | !F)");
-    assertToSop("(!A | D)", "!((!D | !A) & A)");
-    assertToSop("(!D | A)", "((!D & !A) | A)");
+    assertToPos("(A & (!C | !D | !E | !F))", "A & (!A | !C | !D | !E | !F)");
+    assertToSop("(D | !A)", "!((!D | !A) & A)");
+    assertToSop("(A | !D)", "((!D & !A) | A)");
 
   }
 
@@ -58,7 +58,7 @@ public class TestSimplify extends JBoolTestCase {
   public void testExpandLarge() {
 
     //  I didn't actually check this by hand.  See https://github.com/bpodgursky/jbool_expressions/issues/13 for context.
-    assertToSop("((!l & a & g & h & i) | (!l & a & g & h & j) | (!l & a & g & h & k) | (!l & b & g & h & i) | (!l & b & g & h & j) | (!l & b & g & h & k) | (!l & c & g & h & i) | (!l & c & g & h & j) | (!l & c & g & h & k) | (!l & d & g & h & i) | (!l & d & g & h & j) | (!l & d & g & h & k) | (!l & e & g & h & i) | (!l & e & g & h & j) | (!l & e & g & h & k) | (!l & f & g & h & i) | (!l & f & g & h & j) | (!l & f & g & h & k) | m | n)",
+    assertToSop("(m | n | (a & g & h & i & !l) | (a & g & h & j & !l) | (a & g & h & k & !l) | (b & g & h & i & !l) | (b & g & h & j & !l) | (b & g & h & k & !l) | (c & g & h & i & !l) | (c & g & h & j & !l) | (c & g & h & k & !l) | (d & g & h & i & !l) | (d & g & h & j & !l) | (d & g & h & k & !l) | (e & g & h & i & !l) | (e & g & h & j & !l) | (e & g & h & k & !l) | (f & g & h & i & !l) | (f & g & h & j & !l) | (f & g & h & k & !l))",
         "(( a | b | c | d | e | f ) & ( g & h & ( i | j | k ) & !( l | m | n ))) | ( m | n )"
     );
 


### PR DESCRIPTION
Fixes #15

Sorry for the spam. I've changed the branch name for merging in.

For ease of development I upgraded to java 7 and bumped junit. This could be reverted to 1.6.

Equals and hash code implementations were mostly generated using the standard generator in IntelliJ
As expressions are no longer sorted lexicographically the test results have also changed in order. They look the same though.