### PR TITLE
Improve RuleSet#toDNF performance

### DIFF
--- a/src/main/java/com/bpodgursky/jbool_expressions/rules/RuleSet.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/rules/RuleSet.java
@@ -18,7 +18,7 @@ public class RuleSet {
   }
 
   public static <K> Expression<K> toSop(Expression<K> root) {
-    root = applySet(root, new ArrayList<>(Collections.singleton(new DeMorgan<K>())));
+    root = applySet(root, RulesHelper.<K>demorganRules());
     return applySet(root, RulesHelper.<K>toSopRules());
   }
 


### PR DESCRIPTION
This PR improves the performance of the `.toDnf` function. 

While before it applied the `DeMorgan` rules to the raw Expression, this PR first simplifies the expression and then applies the `DeMorgan` rules.

This has improved performance significantly. Various expressions which took ~1min30sec to parse now take ~5 seconds.