### PR TITLE
Make Expression serializable and use Guava optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>14.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/src/main/java/com/bpodgursky/jbool_expressions/And.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/And.java
@@ -5,15 +5,16 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 
 import static com.bpodgursky.jbool_expressions.Seeds.AND_SEED;
 
+import com.google.common.base.Optional;
+
 public class And<K> extends NExpression<K> {
   public static final String EXPR_TYPE = "and";
-  private Optional<String> cachedStringRepresentation = Optional.empty();
+  private Optional<String> cachedStringRepresentation = Optional.absent();
 
   public static <K> And<K> of(Expression<K>[] children, Comparator<Expression> comparator) {
     return new And<K>(children, comparator);

--- a/src/main/java/com/bpodgursky/jbool_expressions/Expression.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/Expression.java
@@ -1,5 +1,6 @@
 package com.bpodgursky.jbool_expressions;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -7,7 +8,7 @@ import java.util.Set;
 
 import com.bpodgursky.jbool_expressions.rules.Rule;
 
-public abstract class Expression<K> {
+public abstract class Expression<K> implements Serializable {
 
   public static final Comparator<Expression> HASH_COMPARATOR = new HashComparator();
 

--- a/src/main/java/com/bpodgursky/jbool_expressions/Not.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/Not.java
@@ -1,5 +1,7 @@
 package com.bpodgursky.jbool_expressions;
 
+import com.google.common.base.Optional;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -9,11 +11,9 @@ import java.util.Set;
 import com.bpodgursky.jbool_expressions.rules.Rule;
 import com.bpodgursky.jbool_expressions.rules.RulesHelper;
 
-import java.util.Optional;
-
 public class Not<K> extends Expression<K> {
   public static final String EXPR_TYPE = "not";
-  private Optional<String> cachedStringRepresentation = Optional.empty();
+  private Optional<String> cachedStringRepresentation = Optional.absent();
 
   private final Expression<K> e;
 

--- a/src/main/java/com/bpodgursky/jbool_expressions/Or.java
+++ b/src/main/java/com/bpodgursky/jbool_expressions/Or.java
@@ -6,14 +6,15 @@ import java.util.List;
 import java.util.Map;
 
 
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.bpodgursky.jbool_expressions.Seeds.OR_SEED;
 
+import com.google.common.base.Optional;
+
 public class Or<K> extends NExpression<K> {
   public static final String EXPR_TYPE = "or";
-  private Optional<String> cachedStringRepresentation = Optional.empty();
+  private Optional<String> cachedStringRepresentation = Optional.absent();
 
   public static <K> Or<K> of(Expression<K>[] children, Comparator<Expression> comparator) {
     return new Or<K>(children, comparator);


### PR DESCRIPTION
Making `Expression` serializable for my use case with Spark.

Also changing Java Optional for Guava Optional because the latter are serializable.