### PR TITLE
Upgrade from Java 1.8 (EOLed) to Java 11

### DIFF
--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -23,10 +23,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: 11
       - name: Test
         run: |
           ./test

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ jbool_expressions is available via maven central (check out Maven central for th
 <dependency>
     <groupId>com.bpodgursky</groupId>
     <artifactId>jbool_expressions</artifactId>
-    <version>1.23</version>
+    <version>1.24</version>
 </dependency>
 ```
 
@@ -229,7 +229,7 @@ jbool_expressions is built with Maven.  To build from source,
 > mvn package
 ```
 
-generates a snapshot jar target/jbool_expressions-1.0-SNAPSHOT.jar.
+generates a snapshot jar target/jbool_expressions-1.25-SNAPSHOT.jar.
 
 To run the test suite locally,
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.5</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Java 1.8 is no longer actively supported. Upgrade the project to more recent Java 11.